### PR TITLE
appdata: add <extends>

### DIFF
--- a/re.rizin.cutter.plugin.rz-ghidra.appdata.xml
+++ b/re.rizin.cutter.plugin.rz-ghidra.appdata.xml
@@ -2,6 +2,7 @@
 <component type="addon">
   <!--Created with jdAppdataEdit 5.1-->
   <id>re.rizin.cutter.plugin.rz-ghidra</id>
+  <extends>re.rizin.cutter</extends>
   <name>rz-ghidra</name>
   <summary>This is an integration of the Ghidra decompiler and Sleigh Disassembler for rizin.</summary>
   <developer_name></developer_name>


### PR DESCRIPTION
This should squash the following warning from `flatpak search`:

    As-WARNING **: 13:30:44.266: re.rizin.cutter.plugin.rz-ghidra was of type addon but had no extends

The ID within the <extends> element should match the host app's ID.

https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Addon.html#tag-extends
says:

> This tag is [sic] refers to the ID of the component this addon is extending.

https://github.com/rizinorg/cutter/blob/dev/src/re.rizin.cutter.appdata.xml#L3
has

    <id>re.rizin.cutter</id>

Fixes #1.
